### PR TITLE
Only hide the input field when the request has passed

### DIFF
--- a/add-comment.html
+++ b/add-comment.html
@@ -72,9 +72,11 @@ Comment element for preview code
       _addComment: function () {
         if (this.comment.replace(/\s/g, '') !== '') {
 
-          const stopLoading = () => {
+          const stopLoading = (errored) => {
             this._loading = false;
-            this._hide();
+            if(!errored){
+              this._hide();
+            }
           }
 
           this.fire('add-comment', { body: this.comment, stopLoading: stopLoading });

--- a/bower.json
+++ b/bower.json
@@ -1,6 +1,6 @@
 {
   "name": "comments",
-  "version": "0.1.3",
+  "version": "0.1.4",
   "description": "Comment element for preview code",
   "authors": [
     "Preview-Code team"

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "comments",
-  "version": "0.1.3",
+  "version": "0.1.4",
   "private": true,
   "main": "index.html",
   "repository": "https://github.com/preview-code/comments.git",

--- a/test/add-comment.html
+++ b/test/add-comment.html
@@ -106,6 +106,20 @@ This code may only be used under the BSD style license found in LICENSE.txt
         assert.equal(elem.hidden, false);
       });
 
+      it('Does not hide, when line-comment fails', function (done) {
+        elem.addEventListener('add-comment', function (e) {
+          e.detail.stopLoading(true);
+          assert.equal(elem.hidden, false);
+          done();
+        });
+
+
+        elem.lineComment = true;
+        var addButton = Polymer.dom(elem.root).querySelector('#add');
+        assert.equal(elem.hidden, false);
+        MockInteractions.tap(addButton);
+      });
+
       it('Cancel hides element when line-comment', function () {
         elem.lineComment = true;
         var cancelButton = Polymer.dom(elem.root).querySelector('#cancel');
@@ -114,7 +128,7 @@ This code may only be used under the BSD style license found in LICENSE.txt
         assert.equal(elem.hidden, true);
       });
 
-      it('No hides button when not line-comment', function () {
+      it('No cancel button, when not a line-comment', function () {
         elem.lineComment = false;
         assert.isTrue(Polymer.dom(elem.root).querySelector('#cancel').hasAttribute('hidden'));
       });


### PR DESCRIPTION
There is a change required in preview-app, which is in preview-code/minimal-frontend#38